### PR TITLE
Add organization-aware admin querysets

### DIFF
--- a/tasks/admin.py
+++ b/tasks/admin.py
@@ -1,0 +1,15 @@
+from django.contrib import admin
+from .models import Task
+
+
+@admin.register(Task)
+class TaskAdmin(admin.ModelAdmin):
+    """Admin for Task model with organization-based query filtering."""
+
+    def get_queryset(self, request):
+        # Use the unscoped manager to access all objects and then filter by the
+        # organization associated with the requesting user.
+        qs = Task.all_objects.all()
+        if request.user.is_superuser:
+            return qs
+        return qs.filter(organization=request.user.organization)

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,0 +1,26 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+
+from .models import Organization, User
+
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    """Admin for the custom User model limited to the requester's organization."""
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        return qs.filter(organization=request.user.organization)
+
+
+@admin.register(Organization)
+class OrganizationAdmin(admin.ModelAdmin):
+    """Admin for Organization model with organization-based filtering."""
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.is_superuser:
+            return qs
+        return qs.filter(id=request.user.organization_id)


### PR DESCRIPTION
## Summary
- restrict admin Task view to current user's organization
- limit User and Organization admins by the requester's organization

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68acc5c3e9a48322aed93fcf8d3e348a