### PR TITLE
Add sample env file and document configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+SECRET_KEY=dev-secret-key
+DEBUG=1
+DB_ENGINE=sqlite
+DB_NAME=multitenant
+DB_USER=postgres
+DB_PASSWORD=password
+DB_HOST=localhost
+DB_PORT=5432

--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
-# Task Management (Django + Ninja)   
-   
-## Quickstart   
-python -m venv venv && source venv/bin/activate   
-pip install -r requirements.txt   
-python manage.py makemigrations   
-python manage.py migrate   
-python.manage.py demo_data   
-python manage.py test   
-python manage.py runserver   
+# Task Management (Django + Ninja)
 
+## Quickstart
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+python manage.py makemigrations
+python manage.py migrate
+python manage.py demo_data
+python manage.py test
+python manage.py runserver
+
+## Environment Variables
+Copy `.env.example` to `.env` and adjust as needed:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| SECRET_KEY | Django secret key used for cryptographic signing. | dev-secret-key |
+| DEBUG | Enable debug mode (`1` turns it on). | 1 |
+| DB_ENGINE | Database backend (`sqlite` or `postgres`). | sqlite |
+| DB_NAME | Postgres database name when using `postgres`. | multitenant |
+| DB_USER | Postgres user when using `postgres`. | postgres |
+| DB_PASSWORD | Postgres user's password. | password |
+| DB_HOST | Postgres host. | localhost |
+| DB_PORT | Postgres port. | 5432 |
+
+## Sample Credentials
+`python manage.py demo_data` creates an organization and a demo user:
+
+- username: `alice`
+- password: `1234`
+
+## Time Tracking
+Each task records timestamps so you can track how long work takes.


### PR DESCRIPTION
## Summary
- provide `.env.example` covering Django secrets, debug, and DB settings
- document environment variables and sample login credentials in README
- note built-in time tracking capability for tasks

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68acc5c2ee488322807baddebc0cbbb7