### PR TITLE
Guard tenant middleware fallback behind DEBUG

### DIFF
--- a/config/multitenancy.py
+++ b/config/multitenancy.py
@@ -1,6 +1,7 @@
 from core.tenant import set_org
 from auth.jwt import decode_token
 from users.models import User
+from django.conf import settings
 
 class OrganizationMiddleware:
     def __init__(self, get_response):
@@ -31,7 +32,7 @@ class OrganizationMiddleware:
                         org_id = None
 
             # 3) fallback (only for dev/testing)
-            if not org_id:
+            if settings.DEBUG and not org_id:
                 q = request.GET.get("org_id")
                 if q and q.isdigit():
                     org_id = int(q)


### PR DESCRIPTION
## Summary
- Guard multitenancy middleware's org lookup from GET parameters behind `settings.DEBUG`
- Ensure tenant context derives from authenticated session or JWT in production

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68acc5b3fe00832296e30c2f238a4ce0