### PR TITLE
Validate org claim in OrganizationMiddleware

### DIFF
--- a/config/multitenancy.py
+++ b/config/multitenancy.py
@@ -23,8 +23,12 @@ class OrganizationMiddleware:
                     try:
                         data = decode_token(token)
                         uid = int(data["sub"])
-                        org_id = data.get("org")
-                        request.user = User.objects.get(pk=int(data["sub"]))
+                        org_claim = data.get("org")
+                        user = User.objects.get(pk=uid)
+                        if org_claim != user.organization_id:
+                            raise ValueError("Organization claim mismatch")
+                        org_id = org_claim
+                        request.user = user
                     except Exception as e:
                         # invalid/expired token → leave user unauthenticated
                         print("JWT Decode failed:", e)

--- a/tests/test_multitenancy.py
+++ b/tests/test_multitenancy.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+
+from auth.jwt import ALGO
+from config.multitenancy import OrganizationMiddleware
+from core.tenant import get_org
+from users.models import Organization, User
+
+
+class OrganizationMiddlewareTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.org1 = Organization.objects.create(name="Org 1")
+        self.org2 = Organization.objects.create(name="Org 2")
+        self.user = User.objects.create_user(
+            username="alice", password="pass", organization=self.org1
+        )
+
+    def _mismatched_token(self) -> str:
+        now = datetime.now(tz=timezone.utc)
+        payload = {
+            "sub": str(self.user.id),
+            "org": self.org2.id,  # mismatched org claim
+            "username": self.user.username,
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(minutes=5)).timestamp()),
+        }
+        return jwt.encode(payload, settings.SECRET_KEY, algorithm=ALGO)
+
+    def test_mismatched_org_claim_rejected(self):
+        token = self._mismatched_token()
+        request = self.factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        captured = {}
+
+        def get_response(req):
+            captured["user"] = getattr(req, "user", None)
+            captured["org"] = get_org()
+            return HttpResponse("ok")
+
+        middleware = OrganizationMiddleware(get_response)
+        middleware(request)
+
+        self.assertIsNone(captured["user"])
+        self.assertIsNone(captured["org"])


### PR DESCRIPTION
## Summary
- reject JWTs when org claim doesn't match user
- add regression test for mismatched org claims

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9addd6c883228c2d3222501c7304