### PR TITLE
docs: add env template and tenancy docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-SECRET_KEY=dev-secret-key
+# Copy this file to .env and replace the placeholder values
+SECRET_KEY=changeme
 DEBUG=1
 DB_ENGINE=sqlite
 DB_NAME=multitenant

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Copy `.env.example` to `.env` and adjust as needed:
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| SECRET_KEY | Django secret key used for cryptographic signing. | dev-secret-key |
+| SECRET_KEY | Django secret key used for cryptographic signing. | changeme |
 | DEBUG | Enable debug mode (`1` turns it on). | 1 |
 | DB_ENGINE | Database backend (`sqlite` or `postgres`). | sqlite |
 | DB_NAME | Postgres database name when using `postgres`. | multitenant |
@@ -23,9 +23,41 @@ Copy `.env.example` to `.env` and adjust as needed:
 | DB_HOST | Postgres host. | localhost |
 | DB_PORT | Postgres port. | 5432 |
 
-## Sample Credentials
-`python manage.py demo_data` creates an organization and a demo user:
+## Multi-Tenancy
+Each `User` belongs to an `Organization`, and data is scoped to the current
+organization via a context variable. Models such as `Task` use a custom manager
+that automatically filters queries to the active tenant, preventing cross-org
+data leaks.
 
-- username: `alice`
-- password: `1234`
+## Test Credentials
+`python manage.py demo_data` seeds two organizations with demo users:
+
+| Organization | Username | Password |
+| --- | --- | --- |
+| OrgA | alice | 1234 |
+| OrgB | bob   | 1234 |
+
+## Deployment Notes
+- Generate a strong `SECRET_KEY` and set `DEBUG=0` in production.
+- Configure database credentials and run migrations.
+- Execute `python manage.py collectstatic` for static assets.
+- Serve the app with a production-ready server such as `gunicorn` or `uvicorn`.
+- A sample `render.yaml` is provided for deployment on Render.
+
+## Time Tracking
+Measure runtime of commands during development:
+
+```
+time python manage.py test
+python manage.py test --timing
+```
+
+## Coverage
+Install `coverage` and generate a report:
+
+```
+pip install coverage
+coverage run manage.py test
+coverage html  # open htmlcov/index.html
+```
 


### PR DESCRIPTION
## Summary
- add placeholder environment template
- document multi-tenancy and deployment notes
- include time tracking, coverage, and demo credentials

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ad9ae34b9c8322a66623989aa3d79c