### PR TITLE
Add priority to task deadline index

### DIFF
--- a/tasks/migrations/0003_org_deadline_priority_idx.py
+++ b/tasks/migrations/0003_org_deadline_priority_idx.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tasks", "0002_initial"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="DROP INDEX IF EXISTS org_deadline_idx",
+            reverse_sql="CREATE INDEX org_deadline_idx ON tasks_task (organization_id, deadline_datetime_with_tz)",
+        ),
+        migrations.AddIndex(
+            model_name="task",
+            index=models.Index(
+                fields=["organization", "deadline_datetime_with_tz", "priority"],
+                name="org_deadline_priority_idx",
+            ),
+        ),
+    ]
+

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -34,5 +34,8 @@ class Task(models.Model):
 
     class Meta:
         indexes = [
-            models.Index(fields=["organization", "deadline_datetime_with_tz"], name="org_deadline_idx"),
+            models.Index(
+                fields=["organization", "deadline_datetime_with_tz", "priority"],
+                name="org_deadline_priority_idx",
+            ),
         ]


### PR DESCRIPTION
## Summary
- index tasks by organization, deadline and priority
- migrate to replace existing index

## Testing
- `SQLITE_PATH=test_db.sqlite3 python manage.py test`
- `SQLITE_PATH=db.sqlite3 python manage.py migrate tasks`
- `SQLITE_PATH=db.sqlite3 python manage.py shell -c "from tasks.models import Task; from users.models import Organization; from django.utils import timezone; import time\norg,_=Organization.objects.get_or_create(name='PerfOrg');\ndeadline=timezone.now();\nTask.all_objects.filter(organization=org).delete();\nTask.all_objects.bulk_create([Task(title=f'Task {i}', organization=org, deadline_datetime_with_tz=deadline, priority=i%5) for i in range(10000)]);\nstart=time.time();\nlist(Task.all_objects.filter(organization=org, deadline_datetime_with_tz=deadline, priority=3));\nprint('Query time:', time.time()-start);\nprint(Task.all_objects.filter(organization=org, deadline_datetime_with_tz=deadline, priority=3).explain())"`


------
https://chatgpt.com/codex/tasks/task_e_68ad9ae070b08322a1f06c03a0937a0a