### PR TITLE
Implement tenant-scoped user manager and update APIs

### DIFF
--- a/config/multitenancy.py
+++ b/config/multitenancy.py
@@ -24,7 +24,7 @@ class OrganizationMiddleware:
                         data = decode_token(token)
                         uid = int(data["sub"])
                         org_id = data.get("org")
-                        request.user = User.objects.get(pk=int(data["sub"]))
+                        request.user = User.all_objects.get(pk=int(data["sub"]))
                     except Exception as e:
                         # invalid/expired token → leave user unauthenticated
                         print("JWT Decode failed:", e)

--- a/users/api_auth.py
+++ b/users/api_auth.py
@@ -1,5 +1,5 @@
 from ninja import Router, Schema
-from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth import get_user_model
 from auth.jwt import create_token
 from ninja.errors import HttpError
 
@@ -21,8 +21,8 @@ class RegisterIn(Schema):
 
 @router.post("/login", response=TokenOut)
 def login(request, payload: LoginIn):
-    user = authenticate(request, username=payload.username, password=payload.password)
-    if not user:
+    user = User.all_objects.filter(username=payload.username).first()
+    if not user or not user.check_password(payload.password):
         raise HttpError(401, "Invalid credentials")
     return {"access_token": create_token(user, minutes=60*8)}
 

--- a/users/api_users.py
+++ b/users/api_users.py
@@ -18,7 +18,7 @@ def list_users(request):
     u = getattr(request, "user", None)
     if not getattr(u, "is_authenticated", False):
         raise HttpError(401, "Unauthorized")
-    qs = User.objects.filter(organization=u.organization).order_by("id")
+    qs = User.objects.all().order_by("id")
     return [UserOut(id=i.id, username=i.username) for i in qs]
 
 @router.post("/", response={201: UserOut})

--- a/users/management/commands/demo_data.py
+++ b/users/management/commands/demo_data.py
@@ -9,12 +9,12 @@ class Command(BaseCommand):
         org_a, _ = Organization.objects.get_or_create(name="OrgA")
         org_b, _ = Organization.objects.get_or_create(name="OrgB")
 
-        alice, _ = User.objects.get_or_create(username="alice", defaults={"organization": org_a})
+        alice, _ = User.all_objects.get_or_create(username="alice", defaults={"organization": org_a})
         if not alice.organization_id:
             alice.organization = org_a
         alice.set_password("1234"); alice.save()
 
-        bob, _ = User.objects.get_or_create(username="bob", defaults={"organization": org_b})
+        bob, _ = User.all_objects.get_or_create(username="bob", defaults={"organization": org_b})
         if not bob.organization_id:
             bob.organization = org_b
         bob.set_password("1234"); bob.save()

--- a/users/models.py
+++ b/users/models.py
@@ -1,5 +1,13 @@
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, UserManager as DjangoUserManager
 from django.db import models
+from core.tenant import get_org
+
+
+class TenantUserManager(DjangoUserManager):
+    def get_queryset(self):
+        qs = super().get_queryset()
+        org_id = get_org()
+        return qs.filter(organization_id=org_id) if org_id else qs.none()
 
 class Organization(models.Model):
     name = models.CharField(max_length=255, unique=True)
@@ -16,3 +24,5 @@ class User(AbstractUser):
         null=False,
         blank=False,
     )
+    objects = TenantUserManager()
+    all_objects = DjangoUserManager()

--- a/users/tests_api_users.py
+++ b/users/tests_api_users.py
@@ -61,7 +61,7 @@ class UsersApiTest(TestCase):
         self.assertEqual(res.status_code, 201, res.content)
         self.assertTrue(
             get_user_model()
-            .objects.filter(username="dave", organization=self.orgA)
+            .all_objects.filter(username="dave", organization=self.orgA)
             .exists()
         )
 

--- a/users/tests_auth.py
+++ b/users/tests_auth.py
@@ -59,7 +59,7 @@ class AuthApiTest(TestCase):
         data = res.json()
         self.assertIn("access_token", data)
         User = get_user_model()
-        new_user = User.objects.get(username="bob")
+        new_user = User.all_objects.get(username="bob")
         self.assertEqual(new_user.organization_id, self.org.id)
 
     def test_register_duplicate_username(self):

--- a/users/tests_user_manager.py
+++ b/users/tests_user_manager.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from users.models import Organization
+from core.tenant import set_org
+
+
+class UserManagerTest(TestCase):
+    def setUp(self):
+        self.orgA = Organization.objects.create(name="OrgA")
+        self.orgB = Organization.objects.create(name="OrgB")
+        User = get_user_model()
+        User.all_objects.create_user(username="alice", password="x", organization=self.orgA)
+        User.all_objects.create_user(username="bob", password="x", organization=self.orgB)
+
+    def tearDown(self):
+        set_org(None)
+
+    def test_user_objects_scoped_by_org(self):
+        set_org(self.orgA.id)
+        usernames = list(get_user_model().objects.values_list("username", flat=True))
+        self.assertEqual(usernames, ["alice"])
+
+        set_org(self.orgB.id)
+        usernames = list(get_user_model().objects.values_list("username", flat=True))
+        self.assertEqual(usernames, ["bob"])


### PR DESCRIPTION
## Summary
- Add TenantUserManager to scope users by organization and expose unscoped all_objects
- Simplify user listing API to rely on automatic tenant scoping
- Adjust authentication and middleware for new manager and add coverage for user scoping

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ad9adebb4883228355d05eab6e211d