### PR TITLE
Guard org override with env flag and document usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ DB_USER=postgres
 DB_PASSWORD=password
 DB_HOST=localhost
 DB_PORT=5432
+ALLOW_ORG_OVERRIDE=0

--- a/README.md
+++ b/README.md
@@ -22,10 +22,29 @@ Copy `.env.example` to `.env` and adjust as needed:
 | DB_PASSWORD | Postgres user's password. | password |
 | DB_HOST | Postgres host. | localhost |
 | DB_PORT | Postgres port. | 5432 |
+| ALLOW_ORG_OVERRIDE | Allow dev-only `org_id` query override. | 0 |
 
 ## Sample Credentials
 `python manage.py demo_data` creates an organization and a demo user:
 
 - username: `alice`
 - password: `1234`
+
+## Simulating Org Context
+
+API requests normally infer the organization from the authenticated user or
+the `org` claim in a JWT token. For tests or local development you can avoid
+query string overrides by setting the organization context directly:
+
+```python
+from core.tenant import set_org
+
+set_org(org.id)
+# run code that queries org-scoped models
+set_org(None)
+```
+
+The legacy `?org_id=` override is disabled by default. It can be re-enabled by
+setting `ALLOW_ORG_OVERRIDE=1` in the environment when running development or
+test code.
 

--- a/config/multitenancy.py
+++ b/config/multitenancy.py
@@ -1,3 +1,5 @@
+import os
+
 from core.tenant import set_org
 from auth.jwt import decode_token
 from users.models import User
@@ -32,7 +34,11 @@ class OrganizationMiddleware:
                         org_id = None
 
             # 3) fallback (only for dev/testing)
-            if settings.DEBUG and not org_id:
+            if (
+                settings.DEBUG
+                and not org_id
+                and os.environ.get("ALLOW_ORG_OVERRIDE")
+            ):
                 q = request.GET.get("org_id")
                 if q and q.isdigit():
                     org_id = int(q)

--- a/tasks/tests_org_override.py
+++ b/tasks/tests_org_override.py
@@ -1,0 +1,38 @@
+import os
+from django.test import TestCase, RequestFactory, override_settings
+from django.http import HttpResponse
+from users.models import Organization
+from core.tenant import get_org
+from config.multitenancy import OrganizationMiddleware
+
+
+class OrgOverrideFlagTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.org = Organization.objects.create(name="OrgA")
+
+    def _call_mw(self, query: str):
+        captured = {}
+
+        def get_response(request):
+            captured["org"] = get_org()
+            return HttpResponse("ok")
+
+        mw = OrganizationMiddleware(get_response)
+        request = self.factory.get(f"/?{query}")
+        request.user = None
+        with override_settings(DEBUG=True):
+            mw(request)
+        return captured.get("org")
+
+    def test_query_param_used_only_with_flag(self):
+        # Without flag the override should be ignored
+        os.environ.pop("ALLOW_ORG_OVERRIDE", None)
+        org_id = self._call_mw(f"org_id={self.org.id}")
+        self.assertIsNone(org_id)
+
+        # With flag the override is honored
+        os.environ["ALLOW_ORG_OVERRIDE"] = "1"
+        org_id = self._call_mw(f"org_id={self.org.id}")
+        self.assertEqual(org_id, self.org.id)
+        os.environ.pop("ALLOW_ORG_OVERRIDE", None)


### PR DESCRIPTION
## Summary
- restrict org query override to `ALLOW_ORG_OVERRIDE` env flag
- document how to simulate org context in tests/dev
- add regression test for org override flag

## Testing
- `python manage.py test` *(fails: No module named 'whitenoise')*
- `pip install whitenoise` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9add2dc88322b9034b15b9cc3c0a