### PR TITLE
Use Field default for task metadata

### DIFF
--- a/tasks/schemas.py
+++ b/tasks/schemas.py
@@ -1,4 +1,4 @@
-from ninja import Schema
+from ninja import Schema, Field
 from typing import Any
 
 class TaskOut(Schema):
@@ -17,7 +17,7 @@ class TaskIn(Schema):
     priority: int = 0
     deadline_datetime_with_tz: str | None = None
     assigned_to_id: int | None = None
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 class TaskUpdate(Schema):
     title: str | None = None

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -1,10 +1,11 @@
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
 from django.core.management import call_command
 from io import StringIO
 from users.models import Organization, User
 from .models import Task
 from django.core.exceptions import ValidationError
 from core.tenant import set_org
+from .schemas import TaskIn
 
 
 class TaskModelTest(TestCase):
@@ -48,3 +49,11 @@ class FindTasksCommandTest(TestCase):
         out = StringIO()
         call_command("find_tasks", "--org", "TestOrg", "--meta", "priority__gt=2", stdout=out)
         self.assertIn("A1", out.getvalue())
+
+
+class TaskSchemaDefaultTest(SimpleTestCase):
+    def test_taskin_metadata_default_is_unique(self):
+        t1 = TaskIn(title="One")
+        t2 = TaskIn(title="Two")
+        t1.metadata["a"] = 1
+        self.assertEqual(t2.metadata, {})


### PR DESCRIPTION
## Summary
- avoid mutable defaults in TaskIn metadata with Field default_factory
- test TaskIn metadata default isolation

## Testing
- `python manage.py test tasks` *(fails: ModuleNotFoundError: No module named 'whitenoise')*
- `pip install whitenoise` *(fails: Could not find a version that satisfies the requirement whitenoise)*
- `python manage.py test tasks.tests`


------
https://chatgpt.com/codex/tasks/task_e_68ad9adc69f883229033cc2ccbba50e1