### PR TITLE
Use all_objects manager for demo tasks

### DIFF
--- a/users/management/commands/demo_data.py
+++ b/users/management/commands/demo_data.py
@@ -19,16 +19,31 @@ class Command(BaseCommand):
             bob.organization = org_b
         bob.set_password("1234"); bob.save()
 
-        Task.objects.get_or_create(title="Fix bug", organization=org_a,
-            defaults={"assigned_to": alice, "metadata": {"sprint": 21, "priority": 5}})
-        Task.objects.get_or_create(title="Build feat", organization=org_a,
-            defaults={"assigned_to": alice, "metadata": {"sprint": 21, "priority": 2}})
-        Task.objects.get_or_create(title="Write docs", organization=org_a,
-            defaults={"assigned_to": alice, "metadata": {"sprint": 22, "priority": 1}})
+        Task.all_objects.get_or_create(
+            title="Fix bug",
+            organization=org_a,
+            defaults={"assigned_to": alice, "metadata": {"sprint": 21, "priority": 5}},
+        )
+        Task.all_objects.get_or_create(
+            title="Build feat",
+            organization=org_a,
+            defaults={"assigned_to": alice, "metadata": {"sprint": 21, "priority": 2}},
+        )
+        Task.all_objects.get_or_create(
+            title="Write docs",
+            organization=org_a,
+            defaults={"assigned_to": alice, "metadata": {"sprint": 22, "priority": 1}},
+        )
 
-        Task.objects.get_or_create(title="Infra setup", organization=org_b,
-            defaults={"assigned_to": bob, "metadata": {"sprint": 7, "env": "prod"}})
-        Task.objects.get_or_create(title="Cost report", organization=org_b,
-            defaults={"assigned_to": bob, "metadata": {"sprint": 7, "budget": 9000}})
+        Task.all_objects.get_or_create(
+            title="Infra setup",
+            organization=org_b,
+            defaults={"assigned_to": bob, "metadata": {"sprint": 7, "env": "prod"}},
+        )
+        Task.all_objects.get_or_create(
+            title="Cost report",
+            organization=org_b,
+            defaults={"assigned_to": bob, "metadata": {"sprint": 7, "budget": 9000}},
+        )
 
         self.stdout.write(self.style.SUCCESS("Demo data created."))


### PR DESCRIPTION
## Summary
- use `Task.all_objects.get_or_create` in demo data command so tasks can seed without tenant context

## Testing
- `SQLITE_PATH=db.sqlite3 python manage.py demo_data`
- `SQLITE_PATH=db.sqlite3 python manage.py shell -c "from tasks.models import Task; from users.models import Organization; org_a=Organization.objects.get(name='OrgA'); org_b=Organization.objects.get(name='OrgB'); print('OrgA tasks', Task.all_objects.filter(organization=org_a).count()); print('OrgB tasks', Task.all_objects.filter(organization=org_b).count())"`
- `SQLITE_PATH=db.sqlite3 python manage.py test` *(fails: ModuleNotFoundError: No module named 'whitenoise')*

------
https://chatgpt.com/codex/tasks/task_e_68ad9adb080c8322835aebfc28df1aaf