### PR TITLE
Remove PostgreSQL references and dependencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,5 @@
 # Copy this file to .env and replace the placeholder values
 SECRET_KEY=changeme
 DEBUG=1
-DB_ENGINE=sqlite
-DB_NAME=multitenant
-DB_USER=postgres
-DB_PASSWORD=password
-DB_HOST=localhost
-DB_PORT=5432
+SQLITE_PATH=/var/app/data/db.sqlite3
 ALLOW_ORG_OVERRIDE=0

--- a/README.md
+++ b/README.md
@@ -16,12 +16,7 @@ Copy `.env.example` to `.env` and adjust as needed:
 | --- | --- | --- |
 | SECRET_KEY | Django secret key used for cryptographic signing. | changeme |
 | DEBUG | Enable debug mode (`1` turns it on). | 1 |
-| DB_ENGINE | Database backend (`sqlite` or `postgres`). | sqlite |
-| DB_NAME | Postgres database name when using `postgres`. | multitenant |
-| DB_USER | Postgres user when using `postgres`. | postgres |
-| DB_PASSWORD | Postgres user's password. | password |
-| DB_HOST | Postgres host. | localhost |
-| DB_PORT | Postgres port. | 5432 |
+| SQLITE_PATH | Path to the SQLite database file. | /var/app/data/db.sqlite3 |
 | ALLOW_ORG_OVERRIDE | Allow dev-only `org_id` query override. | 0 |
 
 ## Multi-Tenancy
@@ -40,7 +35,7 @@ data leaks.
 
 ## Deployment Notes
 - Generate a strong `SECRET_KEY` and set `DEBUG=0` in production.
-- Configure database credentials and run migrations.
+- Run migrations to initialize the SQLite database.
 - Execute `python manage.py collectstatic` for static assets.
 - Serve the app with a production-ready server such as `gunicorn` or `uvicorn`.
 - A sample `render.yaml` is provided for deployment on Render.

--- a/config/settings.py
+++ b/config/settings.py
@@ -72,26 +72,13 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "config.wsgi.application"
 
-DATABASE_ENGINE = os.getenv("DB_ENGINE", "sqlite")
-if DATABASE_ENGINE == "postgres":
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.getenv("DB_NAME", "multitenant"),
-            "USER": os.getenv("DB_USER", "postgres"),
-            "PASSWORD": os.getenv("DB_PASSWORD", "password"),
-            "HOST": os.getenv("DB_HOST", "localhost"),
-            "PORT": os.getenv("DB_PORT", "5432"),
-        }
+DB_FILE = os.getenv("SQLITE_PATH", "/var/app/data/db.sqlite3")
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": DB_FILE,
     }
-else:
-    DB_FILE = os.getenv("SQLITE_PATH", "/var/app/data/db.sqlite3")
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": DB_FILE,
-        }
-    }
+}
     
 
 AUTH_USER_MODEL = "users.User"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@ Django>=5.2,<6.0
 django-ninja>=1.4.3
 PyJWT>=2.9
 python-dotenv>=1.0.1
-psycopg[binary]>=3.1 ; platform_system != "Windows"
-psycopg>=3.1 ; platform_system == "Windows"
 coverage>=7.6
 gunicorn
 whitenoise


### PR DESCRIPTION
## Summary
- drop psycopg from project dependencies
- simplify settings to use SQLite only
- update environment examples and README to remove PostgreSQL variables

## Testing
- `SQLITE_PATH=/tmp/test.sqlite3 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68adb629833083229b26c6337b7ab012